### PR TITLE
Removing bubblewrap from the project list

### DIFF
--- a/data/projects.yml
+++ b/data/projects.yml
@@ -3,6 +3,5 @@
 - vasuki
 - gocd-mesos
 - the-vision
-- bubblewrap
 - apiv2-java-client
 - ind9.github.io


### PR DESCRIPTION
Had a chat with @yellowflash. He's working on a standalone crawler using bubblewrap and wants to release it along with that as a package.
