### PR TITLE
Removing apiv2-java-client and the-vision from oss page

### DIFF
--- a/data/projects.yml
+++ b/data/projects.yml
@@ -4,9 +4,7 @@
 - rocks
 - vasuki
 - gocd-mesos
-- the-vision
 - web-auto-extractor
-- apiv2-java-client
-- Mobile-Product-Search 
+- Mobile-Product-Search
 - utils
 - ind9.github.io


### PR DESCRIPTION
@manojlds @ashwanthkumar, since we have moved [apiv2-java-client](https://github.com/indix-eng/apiv2-java-client) and [the-vision](https://github.com/indix-eng/the-vision) away from **ind9** to **indix-eng** org. So can we remove them from the current OSS page as of now ?

cc : @praveenselvam 
